### PR TITLE
Refactor hooks for Issuer to be simpler and less coupled to outputted HTML

### DIFF
--- a/objects/features/account/account.ts
+++ b/objects/features/account/account.ts
@@ -12,6 +12,6 @@ export class AccountFeature extends AbstractFeature implements IssuerModel {
     @singleCheckbox(By.xpath('.//*[./*[@name="acceptPrivacy"]]/label'), { checkedSelector: By.xpath('//*[@name="acceptPrivacy" and @value="true"]') }) public marketingConsent: boolean;
     @singleCheckbox(By.xpath('.//*[./*[@name="acceptTerms"]]/label'), { checkedSelector: By.xpath('//*[@name="acceptTerms" and @value="true"]') }) public termsOfUse: boolean;
     public next(): Promise<IssuerPage> {
-        return oh.click(By.xpath('.//button[@type="submit" and contains(@class, "bx--btn--primary")]'), this.element).then(() => IssuerPage.Get<IssuerPage>(IssuerPage));
+        return oh.click(By.xpath('.//button[@type="submit"]'), this.element).then(() => IssuerPage.Get<IssuerPage>(IssuerPage));
     }
 }

--- a/objects/features/account/emailValidation.ts
+++ b/objects/features/account/emailValidation.ts
@@ -6,9 +6,9 @@ import { VerificationEmail } from "objects/pages/emails/verification";
 import { IssuerPage } from "objects/pages/base";
 
 class EmailConfirmed extends AbstractFeature {
-    public featureSelector: Locator = By.xpath('//body[.//button[text()="CONTINUE WITH TOKEN CREATION"]]');
+    public featureSelector: Locator = By.xpath('.//*[@id="sign-up-success"]');
     public next(): Promise<IssuerPage> {
-        return oh.click(By.xpath('.//button[contains(@class, "bx--btn--primary")][text()="CONTINUE WITH TOKEN CREATION"]'), this.element).then(() => IssuerPage.Get<IssuerPage>(IssuerPage));
+        return oh.click(By.xpath('.//button[@type="submit"]'), this.element).then(() => IssuerPage.Get<IssuerPage>(IssuerPage));
     }
 }
 
@@ -45,6 +45,6 @@ export class EmailValidationFeature extends AbstractFeature {
     public featureSelector: Locator = By.xpath('.//*[contains(@class,"confirm-email-form")]');
     @inputField<string>(By.xpath('.//*[@name="email"]')) public email: string;
     public next(): Promise<PinFeature> {
-        return oh.click(By.xpath('.//button[@type="submit" and contains(@class, "bx--btn--primary")]'), this.element).then(() => new PinFeature(this.parent).load());
+        return oh.click(By.xpath('.//button[@type="submit"]'), this.element).then(() => new PinFeature(this.parent).load());
     }
 }

--- a/objects/features/mint/createTokenFeature.ts
+++ b/objects/features/mint/createTokenFeature.ts
@@ -23,7 +23,7 @@ import { CountdownFeature } from "objects/features/token/countdown";
 
     public countdown: CountdownFeature = new CountdownFeature(this);
     public async next(): Promise<Modal> {
-        await oh.click(By.xpath('.//button[@type="submit" and contains(@class, "bx--btn--primary")]'), this.element);
+        await oh.click(By.xpath('.//button[@type="submit"]'), this.element);
         return Modal.WaitForPage<Modal>(Modal);
     }
 }

--- a/objects/features/mint/mintFeature.ts
+++ b/objects/features/mint/mintFeature.ts
@@ -10,9 +10,9 @@ import { Modal } from "objects/features/general/modal";
     @inputField<string>(By.xpath('.//input[@type="file"]')) public file: string;
 
     public mint(): Promise<Modal> {
-        return oh.click(By.xpath('.//button[@type="submit" and contains(@class, "bx--btn--primary")]'), this.element).then(() => Modal.WaitForPage<Modal>(Modal));
+        return oh.click(By.xpath('.//button[@class="mint-token-btn"]'), this.element).then(() => Modal.WaitForPage<Modal>(Modal));
     }
     public skip(): Promise<Modal> {
-        return oh.click(By.xpath('.//button[@type="submit" and contains(@class, "bx--btn--secondary")]'), this.element).then(() => Modal.WaitForPage<Modal>(Modal));
+        return oh.click(By.xpath('.//button[@type="skip-minting-btn"]'), this.element).then(() => Modal.WaitForPage<Modal>(Modal));
     }
-}
+}è

--- a/objects/features/mint/mintTokenInfo.ts
+++ b/objects/features/mint/mintTokenInfo.ts
@@ -12,7 +12,7 @@ import { Modal } from "objects/features/general/modal";
     @order(2) @singleCheckbox(By.xpath('.//*[@for="investors-number-toggle"]'), { checkedSelector: By.xpath('//*[@id="maxHoldersCount"][not(ancestor::*[contains(@style,"display: none")])]') }) public allowMaxInvestors: boolean;
     @order(1) @optional @inputField<number>(By.xpath('.//*[@id="maxHoldersCount"]')) public maxInvestors?: number;
     public async download(acceptAndDownload: boolean = true): Promise<DownloadedFile> {
-        let modal = await oh.click(By.xpath('.//*[contains(@class, "bx--btn--secondary")]'), this.element).then(() => Modal.Get<Modal>(Modal));
+        let modal = await oh.click(By.xpath('.//*[contains(@class, "export-tokens-list-btn")]'), this.element).then(() => Modal.Get<Modal>(Modal));
         if (acceptAndDownload) {
             await modal.next(true);
             return await oh.browser.downloadManager.waitForDownload("*.csv");

--- a/objects/features/providers/providerFeature.ts
+++ b/objects/features/providers/providerFeature.ts
@@ -4,5 +4,5 @@ import { AbstractFeature } from "framework/object/abstract";
 
 
 @injectable export class ProviderFeature extends AbstractFeature {
-    protected featureSelector: Locator = By.xpath('.//*[@class="bx--tabs__nav-item"]');
+    protected featureSelector: Locator = By.xpath('.//*[contains(@class, "providers-tab")]');
 }

--- a/objects/features/sto/capped.ts
+++ b/objects/features/sto/capped.ts
@@ -32,7 +32,7 @@ import { Modal } from "objects/features/general/modal";
     @label<number>(By.xpath('.//fieldset'), /(\d+)/, { mode: LabelOptsMode.Text }) public fundsRaised: number;
 
     public next(): Promise<Modal> {
-        return oh.click(By.xpath('.//button[@type="submit" and contains(@class, "bx--btn--primary")]'), this.element).then(() => Modal.WaitForPage<Modal>(Modal));
+        return oh.click(By.xpath('.//button[@type="submit"]'), this.element).then(() => Modal.WaitForPage<Modal>(Modal));
     }
 }
 
@@ -46,7 +46,7 @@ import { Modal } from "objects/features/general/modal";
     @present(By.xpath('.//button[contains(@class, "bx--btn--primary")]')) public hasNext: boolean;
     public seeOnEtherscan() {
         // TODO: Implement Etherscan parser
-        return oh.click(By.xpath('.//button[contains(@class, "bx--btn--secondary")]'), this.element);
+        return oh.click(By.xpath('.//button[contains(@class, "see-on-etherscan-link")]'), this.element);
     }
     public next(): Promise<CappedStoConfig> {
         if (this.hasNext === false) throw `This widget doesn't support the next() function`;

--- a/objects/features/ticker/ticker.ts
+++ b/objects/features/ticker/ticker.ts
@@ -15,7 +15,7 @@ export class TickerFeature extends AbstractFeature implements TickerModel {
     @inputField<string>(By.xpath('.//*[@name="name"]')) public name: string;
     @label<string>(By.xpath('.//*[@name="owner"]'), null, { numberParseMethod: NumberParseMethod.None }) public ethAddress: string;
     public async next(): Promise<Modal | TickerError> {
-        await oh.click(By.xpath('.//button[@type="submit" and contains(@class, "bx--btn--primary")]'), this.element);
+        await oh.click(By.xpath('.//button[@type="submit"]'), this.element);
         return await TickerError.WaitForPage([Modal, TickerError]) as Modal | TickerError;
     }
 }

--- a/objects/features/whitelist/whitelist.ts
+++ b/objects/features/whitelist/whitelist.ts
@@ -11,7 +11,7 @@ class WhitelistModal extends Modal {
     protected featureSelector: Locator = By.xpath('.//*[contains(@class, "whitelist-import-modal") and contains(@class, "is-visible")]');
     @inputField<string>(By.xpath('.//input[@type="file"]')) public file: string;
     public async cancel(lookForNext: boolean = true): Promise<IssuerPage> {
-        return oh.click(By.xpath('.//button[contains(@class, "bx--btn--secondary") and not(@for)]'), this.element).then(() => lookForNext && IssuerPage.WaitForPage(IssuerPage) as Promise<IssuerPage>);
+        return oh.click(By.xpath('.//button[contains(@class, "cancel-btn") and not(@for)]'), this.element).then(() => lookForNext && IssuerPage.WaitForPage(IssuerPage) as Promise<IssuerPage>);
     }
     public upload(file): Promise<void> {
         return oh.type(By.xpath('.//*[@id="id3"]'), file);
@@ -19,7 +19,7 @@ class WhitelistModal extends Modal {
 }
 
 export class WhitelistFeature extends AbstractFeature implements WhitelistModel {
-    public featureSelector: Locator = By.xpath('.//*[contains(@class, "pui-page-box") and contains(@class, "compliance-form")]');
+    public featureSelector: Locator = By.xpath('.//*[@id="compliance"]');
     @order(2) @singleCheckbox(By.xpath('.//label[@for="percentageToggle"][preceding-sibling::*[@id="percentageToggle"]]'),
         {
             checkedSelector: By.xpath('//*[@id="percentage"][not(ancestor::*[contains(@style,"display: none")])]'), postSet: async function () {
@@ -33,15 +33,15 @@ export class WhitelistFeature extends AbstractFeature implements WhitelistModel 
     public async next(): Promise<Modal> {
         // This is more of an 'apply', but we're setting a custom method here
         if (!this.enableOwnershipPermissions) return null;
-        await oh.click(By.xpath('.//button[preceding-sibling::*[@for="percentage"]]'), this.element);
+        await oh.click(By.xpath('.//*[@class="apply-percentage-btn"]'), this.element);
         return Modal.WaitForPage<Modal>(Modal);
     }
     public async import(): Promise<WhitelistModal> {
-        await oh.click(By.xpath('.//*[contains(@class,"import-whitelist-btn") and contains(@class, "bx--btn--primary")]'), this.element);
+        await oh.click(By.xpath('.//*[contains(@class,"import-whitelist-btn")]'), this.element);
         return new WhitelistModal().load();
     }
     public async download(acceptAndDownload: boolean = true): Promise<DownloadedFile> {
-        let modal = await oh.click(By.xpath('.//*[contains(@class,"import-whitelist-btn") and contains(@class, "bx--btn--secondary")]'), this.element).then(() => Modal.Get<Modal>(Modal));
+        let modal = await oh.click(By.xpath('.//*[contains(@class,"import-whitelist-btn")]'), this.element).then(() => Modal.Get<Modal>(Modal));
         if (acceptAndDownload) {
             await modal.next(true);
             return await oh.browser.downloadManager.waitForDownload("*.csv");

--- a/objects/pages/noToken/account/createAccount.ts
+++ b/objects/pages/noToken/account/createAccount.ts
@@ -4,6 +4,6 @@ import { PageWithHeader } from "objects/pages/base";
 import { AccountFeature } from "objects/features/account/account";
 
 @injectable export class AccountPage extends PageWithHeader {
-    protected featureSelector: Locator = By.xpath('.//body[.//*[@name="acceptPrivacy"]]');
+    protected featureSelector: Locator = By.xpath('.//body[.//*[@id="sign-up"]]');
     public account: AccountFeature = new AccountFeature(this);
 }

--- a/objects/pages/noToken/homepage/welcome.ts
+++ b/objects/pages/noToken/homepage/welcome.ts
@@ -4,12 +4,12 @@ import { IssuerPage } from "objects/pages/base";
 import { SignPage } from "objects/pages/noToken/sign/sign";
 
 @injectable export class Welcome extends IssuerPage {
-    protected featureSelector: Locator = By.xpath('.//body[.//button[text()="CREATE YOUR SECURITY TOKEN"]]');
+    protected featureSelector: Locator = By.xpath('.//body[.//*[@id="create-token-btn"]]');
     constructor() {
         super(oh.browser.baseUrl);
     }
     public async next(): Promise<SignPage> {
-        await oh.click(By.xpath('.//button[text()="CREATE YOUR SECURITY TOKEN"]'));
+        await oh.click(By.xpath('.//*[@id="create-token-btn"]'));
         return await new SignPage().load();
     }
 }

--- a/objects/pages/noToken/lockdown/404.ts
+++ b/objects/pages/noToken/lockdown/404.ts
@@ -4,5 +4,5 @@ import { IssuerPage } from "objects/pages/base";
 
 // TODO: Fix these locators
 @injectable export class NotFound extends IssuerPage {
-    protected featureSelector: Locator = By.xpath('.//body[.//h3[text()="Segmentation Fault! – Just kidding it\'s only a 404 – Page Not Found"]]');
+    protected featureSelector: Locator = By.xpath('.//body[.//*[@id="not-found"]]');
 }

--- a/objects/pages/noToken/lockdown/disconnected.ts
+++ b/objects/pages/noToken/lockdown/disconnected.ts
@@ -4,5 +4,5 @@ import { CorePage } from "objects/pages/base";
 
 // TODO: Fix these locators
 @injectable export class Disconnected extends CorePage {
-    protected featureSelector: Locator = By.xpath('.//body[.//h1[text()="Aw, Snap!"]]');
+    protected featureSelector: Locator = By.xpath('.//body[.//*[@:id="disconnected"]]');
 }

--- a/objects/pages/noToken/lockdown/metamaskBlocked.ts
+++ b/objects/pages/noToken/lockdown/metamaskBlocked.ts
@@ -4,5 +4,5 @@ import { CorePage } from "objects/pages/base";
 
 // TODO: Fix these locators
 @injectable export class MetamaskBlocked extends CorePage {
-    protected featureSelector: Locator = By.xpath('.//body[.//h1[text()="Your MetaMask Is Locked"]]');
+    protected featureSelector: Locator = By.xpath('.//body[.//*[@:id="metamask-locked"]]');
 }

--- a/objects/pages/noToken/sign/sign.ts
+++ b/objects/pages/noToken/sign/sign.ts
@@ -4,7 +4,7 @@ import { PageWithHeader } from "objects/pages/base";
 import { Metamask } from "extensions/metamask";
 
 @injectable export class SignPage extends PageWithHeader {
-    protected featureSelector: Locator = By.xpath('//body[.//h2[text()="Sign In with Your Wallet"]]');
+    protected featureSelector: Locator = By.xpath('//body[.//*[@id="sign-in"]]');
     public async next(lookForNext: boolean = true): Promise<PageWithHeader> {
         await Metamask.instance.confirmTransaction();
         return lookForNext && PageWithHeader.WaitForPage(PageWithHeader) as Promise<PageWithHeader>;

--- a/objects/pages/noToken/ticker/ticker.ts
+++ b/objects/pages/noToken/ticker/ticker.ts
@@ -5,6 +5,6 @@ import { TickerFeature } from "objects/features/ticker/ticker";
 import { PageWithHeader } from "objects/pages/base";
 
 @injectable export class Ticker extends PageWithHeader {
-    protected featureSelector: Locator = By.xpath('.//body[.//*[@name="ticker"]]');
+    protected featureSelector: Locator = By.xpath('.//body[.//*[@id="ticker-reservation"]]');
     public ticker: TickerFeature = new TickerFeature(this);
 }

--- a/objects/pages/withToken/base.ts
+++ b/objects/pages/withToken/base.ts
@@ -17,7 +17,7 @@ export function nav<T extends PageWithToken>(navigationKey: Locator) {
 
 // Sadly this is a circular dependency
 export class NavigationFeature extends AbstractFeature {
-    protected featureSelector: Locator = By.xpath('.//*[@class="pui-sidebar"]');
+    protected featureSelector: Locator = By.xpath('.//*[@id="primary-nav"]');
     public async navigate<T extends PageWithToken>(toClass: { new(...args): T }): Promise<T> {
         let key: Locator;
         recurseClass(toClass, obj => {

--- a/objects/pages/withToken/compliance/whitelist.ts
+++ b/objects/pages/withToken/compliance/whitelist.ts
@@ -3,7 +3,7 @@ import { injectable } from "framework/object/core/iConstructor";
 import { nav, PageWithToken } from "objects/pages/withToken/base";
 import { WhitelistFeature } from "objects/features/whitelist/whitelist";
 
-@injectable @nav(By.xpath('.//li[./p[text()="Compliance"]]')) export class Whitelist extends PageWithToken {
-    protected featureSelector: Locator = By.xpath('self::*[.//li[@class="active"][./p[text()="Compliance"]]]');
+@injectable @nav(By.xpath('//*[@id="compliance-nav-link"]')) export class Whitelist extends PageWithToken {
+    protected featureSelector: Locator = By.xpath('self::*[.//li[@class="active"]]');
     public whitelist: WhitelistFeature = new WhitelistFeature(this);
 }

--- a/objects/pages/withToken/providers/providers.ts
+++ b/objects/pages/withToken/providers/providers.ts
@@ -5,8 +5,8 @@ import { nav, PageWithToken } from "objects/pages/withToken/base";
 import { CreateTokenCountdown } from "../../../features/token/countdown";
 import { optional } from "framework/object/abstract";
 
-@injectable @nav(By.xpath('.//li[./p[text()="Providers"]]')) export class Providers extends PageWithToken {
-    protected featureSelector: Locator = By.xpath('self::*[.//li[@class="active"][./p[text()="Providers"]]]');
+@injectable @nav(By.xpath('//*[@id="provider-nav-link"]')) export class Providers extends PageWithToken {
+    protected featureSelector: Locator = By.xpath('self::*[.//li[@class="active"]]');
     @inject(ProviderFeature, { multiInstance: true }) public providers: ProviderFeature[];
     @optional public createToken: CreateTokenCountdown = new CreateTokenCountdown(this);
 }

--- a/objects/pages/withToken/sto/abstract.ts
+++ b/objects/pages/withToken/sto/abstract.ts
@@ -1,6 +1,6 @@
 import { Locator, By } from "framework/helpers";
 import { nav, PageWithToken } from "objects/pages/withToken/base";
 
-@nav(By.xpath('.//li[./p[text()="STO"]]')) export abstract class BaseSto extends PageWithToken {
-    protected featureSelector: Locator = By.xpath('self::*[.//li[@class="active"][./p[text()="STO"]]]');
+@nav(By.xpath('//*[@id="sto-nav-link"]')) export abstract class BaseSto extends PageWithToken {
+    protected featureSelector: Locator = By.xpath('self::*[.//li[@class="active"]]');
 }

--- a/objects/pages/withToken/token/abstract.ts
+++ b/objects/pages/withToken/token/abstract.ts
@@ -2,6 +2,6 @@ import { Locator, By } from "framework/helpers";
 import { nav, PageWithToken } from "objects/pages/withToken/base";
 
 
-@nav(By.xpath('.//li[./p[text()="Token"]]')) export abstract class BaseToken extends PageWithToken {
-    protected featureSelector: Locator = By.xpath('self::*[.//li[@class="active"][./p[text()="Token"]]]');
+@nav(By.xpath('//*[@id="token-nav-link"]')) export abstract class BaseToken extends PageWithToken {
+    protected featureSelector: Locator = By.xpath('self::*[.//li[@class="active"]]');
 }


### PR DESCRIPTION
Hey Josep!

_This PR can be testing with the code of that PR: https://github.com/PolymathNetwork/polymath-apps/pull/13_

Could you check that what I did seems fine to you?
Unfortunately I wasn't able to test these changes as I'm having an error when running `yarn test` so there is probably some mistakes. Plus I believe the config is not yet setup to test the code of the new `polymath-apps` repo yet anyway.

```
Unhandled rejection ReferenceError: è is not defined
    at Object.<anonymous> (/Users/neverbland/Sites/polymath/Polymath-Tests/objects/features/mint/mintFeature.ts:37:1)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Module.m._compile (/Users/neverbland/Sites/polymath/Polymath-Tests/node_modules/ts-node/src/index.ts:439:23)
    at Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Object.require.extensions.(anonymous function) [as .ts] (/Users/neverbland/Sites/polymath/Polymath-Tests/node_modules/ts-node/src/index.ts:442:12)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at /Users/neverbland/Sites/polymath/Polymath-Tests/node_modules/cucumber/src/cli/index.js:63:42
    at Array.forEach (<anonymous>)
    at Cli.getSupportCodeLibrary (/Users/neverbland/Sites/polymath/Polymath-Tests/node_modules/cucumber/src/cli/index.js:63:22)
    at Cli.<anonymous> (/Users/neverbland/Sites/polymath/Polymath-Tests/node_modules/cucumber/src/cli/index.js:78:37)
    at Generator.next (<anonymous>)
    at Generator.tryCatcher (/Users/neverbland/Sites/polymath/Polymath-Tests/node_modules/bluebird/js/release/util.js:16:23)
    at PromiseSpawn._promiseFulfilled (/Users/neverbland/Sites/polymath/Polymath-Tests/node_modules/bluebird/js/release/generators.js:97:49)
    at Promise._settlePromise (/Users/neverbland/Sites/polymath/Polymath-Tests/node_modules/bluebird/js/release/promise.js:574:26)
    at Promise._settlePromise0 (/Users/neverbland/Sites/polymath/Polymath-Tests/node_modules/bluebird/js/release/promise.js:614:10)
    at Promise._settlePromises (/Users/neverbland/Sites/polymath/Polymath-Tests/node_modules/bluebird/js/release/promise.js:693:18)
    at Async._drainQueue (/Users/neverbland/Sites/polymath/Polymath-Tests/node_modules/bluebird/js/release/async.js:133:16)
    at Async._drainQueues (/Users/neverbland/Sites/polymath/Polymath-Tests/node_modules/bluebird/js/release/async.js:143:10)
```

Thanks!